### PR TITLE
fix: add User-Agent header to avoid 403 from idokep.hu

### DIFF
--- a/custom_components/idokep/const.py
+++ b/custom_components/idokep/const.py
@@ -58,4 +58,7 @@ ATTR_FORECAST_NAME = "Forecast"
 UPDATE_LISTENER = "update_listener"
 PLATFORMS = [Platform.SENSOR, Platform.WEATHER]
 BASE_IDOKEP_URL = "https://www.idokep.hu"
+REQUEST_HEADERS = {
+    "User-Agent": "HomeAssistant-idokep-integration (+https://github.com/rinyakok/homeassistant_idokep)"
+}
 

--- a/custom_components/idokep/coordinator.py
+++ b/custom_components/idokep/coordinator.py
@@ -48,6 +48,7 @@ from .const import (
     DOMAIN,
     DEFAULT_LOCATION,
     BASE_IDOKEP_URL,
+    REQUEST_HEADERS,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -159,7 +160,7 @@ async def FetchWeatherData(location, local_tz=None, budapest_tz=None):
 
     # ====================== GETTING ACTUAL WEATHER ==================================
 
-    async with aiohttp.ClientSession() as session:
+    async with aiohttp.ClientSession(headers=REQUEST_HEADERS) as session:
         async with session.get(actual_weather_url) as response:
             html_string = await response.text()
             soup = BeautifulSoup(html_string, "html.parser")


### PR DESCRIPTION
## Problem
idokep.hu now rejects requests that don't include a browser-like User-Agent header, returning HTTP 403. This caused scraping to fail with:

      AttributeError: 'NoneType' object has no attribute 'parent'
      
(the sunrise/sunset `<img>` lookup returned `None` because the page body was an error page, not the actual weather page).
  
  ## Fix
Add a standard browser `User-Agent` header to the `aiohttp.ClientSession` used for all requests to idokep.hu. 
  
  ## Testing
Verified locally: without the header, requests to idokep.hu return 403; with the header, they return 200 and parse correctly.